### PR TITLE
Update regx to allow for the use of underscores and hyphens in the us…

### DIFF
--- a/app/models/regular_expressions.rb
+++ b/app/models/regular_expressions.rb
@@ -1,3 +1,3 @@
 module RegularExpressions
-  UPDATE_KARMA_BY_NAME = /(^[\w\.\@]+\s?[-|\+]{2}$)+/
+  UPDATE_KARMA_BY_NAME = /(^[\w\.\@\-\_]+\s?[-|\+]{2}$)+/
 end

--- a/test/models/regular_expressions_test.rb
+++ b/test/models/regular_expressions_test.rb
@@ -21,6 +21,18 @@ class RegularExpressionsTest < ActiveSupport::TestCase
     assert_not_nil RegularExpressions::UPDATE_KARMA_BY_NAME.match("alan --")
   end
 
+  test "UPDATE_KARMA_BY_NAME matches when there is a hyphen in the user name" do
+
+    assert_not_nil RegularExpressions::UPDATE_KARMA_BY_NAME.match("the-alan --")
+    assert_not_nil RegularExpressions::UPDATE_KARMA_BY_NAME.match("the-alan ++")
+  end
+
+  test "UPDATE_KARMA_BY_NAME matches when there is an underscore in the user name" do
+
+    assert_not_nil RegularExpressions::UPDATE_KARMA_BY_NAME.match("the_alan --")
+    assert_not_nil RegularExpressions::UPDATE_KARMA_BY_NAME.match("the_alan ++")
+  end
+
   test "UPDATE_KARMA_BY_NAME does not match unless the string starts with something like a username" do
     assert_nil RegularExpressions::UPDATE_KARMA_BY_NAME.match("Blah blah blah --")
     assert_nil RegularExpressions::UPDATE_KARMA_BY_NAME.match("Blah blah blah ++")


### PR DESCRIPTION
…er name

My RegX was too restrictive to allow for user names that include hyphens or underscores.  This PR adds support for both and matching tests.